### PR TITLE
Add Delete key, ESC q, and fix warning

### DIFF
--- a/src/debugger.c
+++ b/src/debugger.c
@@ -570,7 +570,7 @@ bool command_entry(WINDOW *win, char *cmdbuf, size_t *cmdbuf_index, int c)
 
     wattron(win, A_BOLD);
 
-    if (c == KEY_BACKSPACE || c == KEY_CTRL_H) {
+    if (c == KEY_BACKSPACE || c == KEY_CTRL_H || c == KEY_DELETE) {
         if (*cmdbuf_index > 0) {
             mvwaddch(win, 1, (*cmdbuf_index) + CMD_DISP_X_OFFS, ' '); // Erase cursor
             cmdbuf[*cmdbuf_index] = '\0';
@@ -715,7 +715,8 @@ cmd_status_t command_execute(cmd_err_t *status, char *_cmdbuf, int cmdbuf_index,
             cpu->P.IRQ = 0;
         }
         else {
-            return CMD_UNKNOWN_ARG;
+            *status = CMD_UNKNOWN_ARG;
+            return STAT_ERR;
         }
         *status = CMD_OK;
         return STAT_OK;
@@ -1698,7 +1699,7 @@ int main(int argc, char *argv[])
     // Event loop
     prev_c = c = EOF;
     // F12 F12 = exit
-    while (!cmd_exit && !(c == KEY_F(12) && prev_c == KEY_F(12))) {
+    while (!cmd_exit && !(c == KEY_F(12) && prev_c == KEY_F(12)) && !(c == 'q' && prev_c == KEY_ESCAPE)) {
 
         // Handle key press
         switch (c) {
@@ -1920,6 +1921,8 @@ int main(int argc, char *argv[])
         }
     }
     
+    printf("Quitting...\n");
+
     delwin(watch1.win);
     delwin(watch2.win);
     delwin(win_cpu);

--- a/src/debugger.c
+++ b/src/debugger.c
@@ -1920,8 +1920,6 @@ int main(int argc, char *argv[])
             c = getch();
         }
     }
-    
-    printf("Quitting...\n");
 
     delwin(watch1.win);
     delwin(watch2.win);

--- a/src/debugger.h
+++ b/src/debugger.h
@@ -16,6 +16,7 @@
 #define KEY_CTRL_H 8
 #define KEY_CR 10
 #define KEY_ESCAPE 27
+#define KEY_DELETE 127
 
 #define MAX_CMD_LEN 40
 


### PR DESCRIPTION
I have one other change locally, which is Mac specific. I didn't know if removing it entirely was the way to go, so I didn't include it in this PR.

```diff
diff --git a/src/16C750.c b/src/16C750.c
index a416958..53e085c 100644
--- a/src/16C750.c
+++ b/src/16C750.c
@@ -130,16 +130,6 @@ int init_port_16c750(tl16c750_t *uart, uint16_t port)
     if (ret < 0) {
         return errno;
     }
-
-    // Set maximum unack timeout for the TCP connection
-    ret = setsockopt(
-        uart->sock_fd,
-        IPPROTO_TCP,
-        TCP_USER_TIMEOUT,
-        &(uart->sock_timeout),
-        sizeof(uart->sock_timeout) // ???? optLen
-        );
-
     
     if (ret < 0) {
         return errno;
```